### PR TITLE
Add cd && ls commands

### DIFF
--- a/CLI/src/main/java/com/example/CLI/Commands/Cat.java
+++ b/CLI/src/main/java/com/example/CLI/Commands/Cat.java
@@ -2,6 +2,7 @@ package com.example.CLI.Commands;
 
 import com.example.CLI.Environment.Informant;
 import com.example.CLI.Environment.Informed;
+import com.example.CLI.PathUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.ByteArrayInputStream;
@@ -36,7 +37,8 @@ public class Cat implements Command, Informed {
                 errors.addAll(result.getErrors());
                 for (var file: result.getOutput()) {
                     try {
-                        var scanner = new Scanner(new ByteArrayInputStream(informant.getAndClose(file)));
+                        var name = PathUtils.pathToAbsolute(file);
+                        var scanner = new Scanner(new ByteArrayInputStream(informant.getAndClose(name)));
                         while (scanner.hasNext()) {
                             output.add(scanner.nextLine());
                         }

--- a/CLI/src/main/java/com/example/CLI/Commands/Cd.java
+++ b/CLI/src/main/java/com/example/CLI/Commands/Cd.java
@@ -1,0 +1,76 @@
+package com.example.CLI.Commands;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Команда 'cd' меняет текущую директорию на указанную.
+ * Если нет параметров, переходит в домашнюю директорию.
+ */
+public class Cd implements Command {
+    @NotNull
+    private List<Operation> args = Collections.emptyList();
+
+    /**
+     * Получает домашнюю директорию.
+     */
+    public static String getHomeDirectory() {
+        return System.getProperty("user.home");
+    }
+
+    /**
+     * Изменяет текущую директорию.
+     */
+    public static void changeCurrentDirectory(String directory) throws IOException {
+        final var dir = new File(directory);
+        var changeToDirectory = "";
+        if (dir.isAbsolute()) {
+            changeToDirectory = dir.getCanonicalPath();
+        } else {
+            final var parent = Pwd.currentDirectory();
+            changeToDirectory = new File(parent, directory).getCanonicalPath();
+        }
+        if (!new File(changeToDirectory).exists()) {
+            throw new IOException("No such file or directory: " + changeToDirectory);
+        }
+        System.setProperty("user.dir", changeToDirectory);
+    }
+
+    @NotNull
+    private static Result illegalArgumentsResult(@NotNull ArrayList<String> errors) {
+        errors.add("Usage \'cd\': cd [DIR]");
+        return new Result(new ArrayList<>(), errors);
+    }
+
+    @Override
+    public Result execute() {
+        final var errors = new ArrayList<String>();
+        var directory = "";
+        final var stringArgs = executeArgs(args, errors);
+        if (stringArgs.size() == 0) {
+            directory = getHomeDirectory();
+        } else if (stringArgs.size() == 1) {
+            directory = stringArgs.get(0);
+        } else {
+            return illegalArgumentsResult(errors);
+        }
+
+        try {
+            changeCurrentDirectory(directory);
+        } catch (IOException e) {
+            errors.add("Error while changing to directory \'" + directory + "\': " + e.getMessage());
+        }
+
+        return new Result(new ArrayList<>(), errors);
+    }
+
+    @Override
+    public void setArgs(@NotNull ArrayList<Operation> args) {
+        this.args = args;
+    }
+}

--- a/CLI/src/main/java/com/example/CLI/Commands/Command.java
+++ b/CLI/src/main/java/com/example/CLI/Commands/Command.java
@@ -3,6 +3,7 @@ package com.example.CLI.Commands;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Каждая команда наследуется от этого интерфейса.
@@ -17,4 +18,21 @@ public interface Command extends Operation {
      * @param args - объекты классов, реализующих интерфейс Operation
      */
     void setArgs(@NotNull ArrayList<Operation> args);
+
+    /**
+     * Вычисляет аргументы команды.
+     *
+     * @param args   список аргументов команды
+     * @param errors список, куда складываются ошибки при выполнении
+     * @return список результатов
+     */
+    default List<String> executeArgs(@NotNull List<Operation> args, @NotNull List<String> errors) {
+        final var result = new ArrayList<String>();
+        for (var arg : args) {
+            final var argResult = arg.execute();
+            errors.addAll(argResult.getErrors());
+            result.addAll(argResult.getOutput());
+        }
+        return result;
+    }
 }

--- a/CLI/src/main/java/com/example/CLI/Commands/External.java
+++ b/CLI/src/main/java/com/example/CLI/Commands/External.java
@@ -65,7 +65,8 @@ public class External implements Command, Informed {
             }
             result.addErrors(result.getErrors());
         }
-        var processBuilder = new ProcessBuilder(command);
+        var processBuilder = new ProcessBuilder(command)
+                .directory(new File(Pwd.currentDirectory()));
 
         if (connections.size() > 0) {
             try {

--- a/CLI/src/main/java/com/example/CLI/Commands/Ls.java
+++ b/CLI/src/main/java/com/example/CLI/Commands/Ls.java
@@ -1,5 +1,6 @@
 package com.example.CLI.Commands;
 
+import com.example.CLI.PathUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -57,7 +58,7 @@ public class Ls implements Command {
      * @throws IOException если переданный путь к директории невалидный
      */
     public static List<String> listDirectoryContents(@NotNull String directory) throws IOException {
-        return Files.list(new File(directory).toPath())
+        return Files.list(new File(PathUtils.pathToAbsolute(directory)).toPath())
                 .map(path -> path.getFileName().toString())
                 .collect(Collectors.toList());
     }

--- a/CLI/src/main/java/com/example/CLI/Commands/Ls.java
+++ b/CLI/src/main/java/com/example/CLI/Commands/Ls.java
@@ -1,0 +1,64 @@
+package com.example.CLI.Commands;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Команда 'ls' выводит содержимое директории, переданной в параметре или, если нет параметров, текущей директории.
+ */
+public class Ls implements Command {
+    @NotNull
+    private List<Operation> args = Collections.emptyList();
+
+    @Override
+    public Result execute() {
+        final var output = new ArrayList<String>();
+        final var errors = new ArrayList<String>();
+        var directory = "";
+        var stringArgs = executeArgs(args, errors);
+        if (stringArgs.size() == 0) {
+            directory = Pwd.currentDirectory();
+        } else if (stringArgs.size() == 1) {
+            directory = stringArgs.get(0);
+        } else {
+            return illegalArgumentsResult(errors);
+        }
+        try {
+            final var contents = listDirectoryContents(directory);
+            output.addAll(contents);
+        } catch (IOException e) {
+            errors.add("Error while searching in directory \'" + directory + "\'");
+        }
+        return new Result(output, errors);
+    }
+
+    @NotNull
+    private static Result illegalArgumentsResult(@NotNull ArrayList<String> errors) {
+        errors.add("Usage \'ls\': ls [DIR]");
+        return new Result(new ArrayList<>(), errors);
+    }
+
+    @Override
+    public void setArgs(@NotNull ArrayList<Operation> args) {
+        this.args = args;
+    }
+
+    /**
+     * Список имен файлов в директории.
+     *
+     * @param directory директория для поиска
+     * @throws IOException если переданный путь к директории невалидный
+     */
+    public static List<String> listDirectoryContents(@NotNull String directory) throws IOException {
+        return Files.list(new File(directory).toPath())
+                .map(path -> path.getFileName().toString())
+                .collect(Collectors.toList());
+    }
+}

--- a/CLI/src/main/java/com/example/CLI/Commands/Pwd.java
+++ b/CLI/src/main/java/com/example/CLI/Commands/Pwd.java
@@ -11,12 +11,16 @@ import java.util.Collections;
 public class Pwd implements Command {
     @Override
     public Result execute() {
-        var dir = System.getProperty("user.dir");
+        var dir = currentDirectory();
         return new Result(new ArrayList<>(Collections.singletonList(dir)), new ArrayList<>());
     }
 
     @Override
     public void setArgs(@NotNull ArrayList<Operation> args) {
         // Useless for this particular command.
+    }
+
+    public static String currentDirectory() {
+        return System.getProperty("user.dir");
     }
 }

--- a/CLI/src/main/java/com/example/CLI/Commands/Wc.java
+++ b/CLI/src/main/java/com/example/CLI/Commands/Wc.java
@@ -2,6 +2,7 @@ package com.example.CLI.Commands;
 
 import com.example.CLI.Environment.Informant;
 import com.example.CLI.Environment.Informed;
+import com.example.CLI.PathUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.ByteArrayInputStream;
@@ -41,7 +42,8 @@ public class Wc implements Command, Informed {
 
                 for (var file: result.getOutput()) {
                     try {
-                        var bytes = informant.getAndClose(file);
+                        var name = PathUtils.pathToAbsolute(file);
+                        var bytes = informant.getAndClose(name);
                         var scanner = new Scanner(new ByteArrayInputStream(bytes));
 
                         int lines = 0;

--- a/CLI/src/main/java/com/example/CLI/Parser/ParserBuilder.java
+++ b/CLI/src/main/java/com/example/CLI/Parser/ParserBuilder.java
@@ -23,6 +23,8 @@ public class ParserBuilder {
         commands.put("cat", () -> new Cat(informant));
         commands.put("pwd", Pwd::new);
         commands.put("wc", () -> new Wc(informant));
+        commands.put("ls", Ls::new);
+        commands.put("cd", Cd::new);
         var context = new SimpleContext(commands, (name) -> new External(name, informant));
 
         var rules = new ArrayList<Rule>();

--- a/CLI/src/main/java/com/example/CLI/PathUtils.java
+++ b/CLI/src/main/java/com/example/CLI/PathUtils.java
@@ -1,0 +1,17 @@
+package com.example.CLI;
+
+import com.example.CLI.Commands.Pwd;
+
+import java.io.File;
+import java.nio.file.Path;
+
+public class PathUtils {
+    public static String pathToAbsolute(String pathString) {
+        var path = Path.of(pathString);
+        if (path.isAbsolute()) {
+            return pathString;
+        } else {
+            return new File(Pwd.currentDirectory(), pathString).getAbsolutePath();
+        }
+    }
+}

--- a/CLI/src/test/java/com/example/CLI/Commands/CdTest.java
+++ b/CLI/src/test/java/com/example/CLI/Commands/CdTest.java
@@ -1,0 +1,55 @@
+package com.example.CLI.Commands;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CdTest {
+
+    private String workingDirectory = "";
+
+    @BeforeEach
+    void init() {
+        workingDirectory = Pwd.currentDirectory();
+    }
+
+    @AfterEach
+    void returnBack() throws IOException {
+        Cd.changeCurrentDirectory(workingDirectory);
+    }
+
+    @Test
+    void changeCurrentDirectoryToHome() {
+        new Cd().execute();
+        assertEquals(Cd.getHomeDirectory(), Pwd.currentDirectory());
+    }
+
+    @Test
+    void changeCurrentDirectoryUp() throws IOException {
+        final var command = new Cd();
+        final var args = new ArrayList<Operation>();
+        args.add(new Literal(".."));
+        command.setArgs(args);
+        command.execute();
+        final var files = Ls.listDirectoryContents(Pwd.currentDirectory());
+        assertTrue(files.contains("CLI"));
+    }
+
+    @Test
+    void changeCurrentDirectoryToSrc() throws IOException {
+        final var command = new Cd();
+        final var args = new ArrayList<Operation>();
+        args.add(new Literal("src"));
+        command.setArgs(args);
+        command.execute();
+        final var files = Ls.listDirectoryContents(Pwd.currentDirectory());
+        assertTrue(files.contains("main"));
+        assertTrue(files.contains("test"));
+    }
+}

--- a/CLI/src/test/java/com/example/CLI/Commands/CdTest.java
+++ b/CLI/src/test/java/com/example/CLI/Commands/CdTest.java
@@ -52,4 +52,25 @@ class CdTest {
         assertTrue(files.contains("main"));
         assertTrue(files.contains("test"));
     }
+
+    @Test
+    void cdAndLs() throws IOException {
+        final var command = new Cd();
+        final var args = new ArrayList<Operation>();
+        args.add(new Literal("src"));
+        command.setArgs(args);
+        command.execute();
+        final var files = Ls.listDirectoryContents("main");
+        assertTrue(files.contains("java"));
+    }
+
+    @Test
+    void cdToIllegalDirectory() {
+        final var command = new Cd();
+        final var args = new ArrayList<Operation>();
+        args.add(new Literal("sr"));
+        command.setArgs(args);
+        var result = command.execute();
+        assertEquals(1, result.getErrors().size());
+    }
 }

--- a/CLI/src/test/java/com/example/CLI/Commands/LsTest.java
+++ b/CLI/src/test/java/com/example/CLI/Commands/LsTest.java
@@ -1,0 +1,31 @@
+package com.example.CLI.Commands;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LsTest {
+
+    @Test
+    void listDirectoryContents() throws IOException {
+        var files = Ls.listDirectoryContents(Pwd.currentDirectory());
+        assertTrue(files.contains("src"));
+        assertTrue(files.contains("build.gradle"));
+    }
+
+    @Test
+    void listDirectoryContentsUp() throws IOException {
+        var files = Ls.listDirectoryContents("..");
+        assertTrue(files.contains("CLI"));
+    }
+
+    @Test
+    void listDirectoryContentsDown() throws IOException {
+        var files = Ls.listDirectoryContents("src");
+        assertTrue(files.contains("main"));
+    }
+
+
+}


### PR DESCRIPTION
Ревью:
Добавить новые команды было не сложно - добавить одну строчку в парсер(можно было бы сделать фабрику команд).
Неудобные моменты:
1) args можно передавать в конструктор или execute, не очень удобно создавать команду, а потом делать setArgs
2) в каждой команде создается массив с ошибками, потом туда складываются ошибки аргументов -- не лучше бы передавать массив ошибок в аргументы
3) ответственность за ошибки должна быть на Operation, а не на том, кто ее запускает (это не совсем так для аргументов)
4) наверное, это хорошее обобщение, что аргументы - это список Operation, но достать ровно 1 аргумент очень сложно, так как каждый Operation тоже возвращает список

